### PR TITLE
fix: use with jsx for

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,15 @@ export default function({ types: t }, options = {}) {
           });
         }
       },
-      JSXIdentifier(path) {
+      JSXOpeningElement(path) {
         const rootPath = path.findParent(p => p.isProgram());
         const { node } = path;
-        if (node.name === FRAGMENT) {
+        
+        if (t.isJSXIdentifier(node.name, { name: FRAGMENT })) {
           if (rootPath.__jsxfragment === false) {
             addImportStatement(rootPath, moduleName, t);
             rootPath.__jsxfragment = true;
           }
-          path.stop();
         }
       }
     }


### PR DESCRIPTION
原代码的 `path.stop` 导致不处理 `Fragment` 的  `attributes`，导致 `x-for` 一起使用时，无法编译 `x-for`